### PR TITLE
add method to clear old indices

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -39,9 +39,7 @@ rules:
   new-cap:
     - 2
     - newIsCapExceptions: ["kayvee.logger"]
-  no-param-reassign:
-    - 2
-    - props: false
+  no-param-reassign: 0
   key-spacing:
     - 2
     - mode: "minimum"

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ A collection of tools for maintaining an Elasticsearch cluster. Most tools are w
 # API
 
   - **/status/indices** - returns the indexes as json
+  - **/indices/clear** - remove any indexes older than 14 days
 
 # Local Development
 

--- a/config.ts
+++ b/config.ts
@@ -1,3 +1,6 @@
+var fs   = require("fs");
+var yaml = require("js-yaml");
+
 const missing_vars = [];
 const env_var_defaults = {
   PORT:                   8001,
@@ -24,3 +27,18 @@ for (const key of Object.keys(env_var_defaults)) {
 if (missing_vars.length > 0) {
   throw new Error(`Missing env variables: ${missing_vars.join(", ")}`);
 }
+
+// Get document, or throw exception on error
+const conf = yaml.safeLoad(fs.readFileSync("./config.yml", "utf8"));
+
+if (!conf.indices) {
+  throw new Error("missing index configuration");
+}
+if (!conf.indices.prefix) {
+  throw new Error("missing log prefix");
+}
+if (!conf.indices.days) {
+  throw new Error("missing number of days to keep");
+}
+
+module.exports.indices = conf.indices;

--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,8 @@
+indices:
+  # We assume that all indices are named as {prefix}-YYYY.MM.DD
+  prefix: "logs"
+  # How many days of indices to keep
+  days: 14
+  # OPTIONAL: Cron timestamp (sec, min, hour, day of month, month, day of week) in UTC.
+  # If specified, clears the old indices at that interval.
+  clearAt: "0 0 9 * * *" # 2 am PT is 9 am UTC

--- a/lib/elasticsearch.ts
+++ b/lib/elasticsearch.ts
@@ -52,15 +52,12 @@ export function get_indices() {
   });
 }
 
-// Keep 14 days of indexes
-const NUM_DAYS = 14;
-
 function filter_old_indices(current_indices) {
   return new Promise((resolve) => {
     const acceptable_indices = [];
     let today = moment();
-    for (let i = 0; i < NUM_DAYS; i++) {
-      acceptable_indices.push(`logs-${today.format("YYYY.MM.DD")}`);
+    for (let i = 0; i < config.indices.days; i++) {
+      acceptable_indices.push(`${config.indices.prefix}-${today.format("YYYY.MM.DD")}`);
       today = today.subtract(1, "days");
     }
     const indices = _.difference(current_indices, acceptable_indices);

--- a/lib/elasticsearch.ts
+++ b/lib/elasticsearch.ts
@@ -65,8 +65,16 @@ function filter_old_indices(current_indices) {
   });
 }
 
+// delete_index that takes in an index to delete, deletes it, and returns the name of the index that
+// was deleted or an error
+function delete_index(index) {
+  return new Promise((resolve, reject) => {
+    request_es("del", `/${index}`).then(() => resolve(index)).catch(reject);
+  });
+}
+
 function delete_indices(indices) {
-  return Promise.all(_.map(indices, (index) => request_es("del", `/${index}`)));
+  return Promise.all(_.map(indices, (index) => delete_index(index)));
 }
 
 export function clear_old_indices() {

--- a/lib/elasticsearch.ts
+++ b/lib/elasticsearch.ts
@@ -52,9 +52,8 @@ export function get_indices() {
   });
 }
 
-// We want to keep 14 days of indices. Let's do 15 so I don't have to think hard about what happens
-// when the time is in UTC or when we're before/after midnight.
-const NUM_DAYS = 15;
+// Keep 14 days of indexes
+const NUM_DAYS = 14;
 
 function filter_old_indices(current_indices) {
   return new Promise((resolve) => {

--- a/lib/elasticsearch.ts
+++ b/lib/elasticsearch.ts
@@ -14,9 +14,9 @@ const auth = {
 // a promise with the decoded result.
 function request_es(method, path) {
   return new Promise((resolve, reject) => {
-    method = method.toLowerCase()
+    method = method.toLowerCase();
     if (!_.contains(["put", "patch", "post", "head", "del", "get"], method)) {
-      reject(new Error(`Invalid method ${method}`))
+      reject(new Error(`Invalid method ${method}`));
     }
     const url = config.ELASTICSEARCH_URL + path;
     request[method]({url, auth}, (error, response, body) => {
@@ -57,23 +57,22 @@ export function get_indices() {
 const NUM_DAYS = 15;
 
 function filter_old_indices(current_indices) {
-  return new Promise((resolve, reject) => {
+  return new Promise((resolve) => {
     const acceptable_indices = [];
     let today = moment();
     for (let i = 0; i < NUM_DAYS; i++) {
       acceptable_indices.push(`logs-${today.format("YYYY.MM.DD")}`);
-      today = today.subtract(1, 'days');
+      today = today.subtract(1, "days");
     }
-    current_indices.push('fake-index');
     const indices = _.difference(current_indices, acceptable_indices);
     resolve(indices);
-  })
+  });
 }
 
 function delete_indices(indices) {
-  return Promise.all(_.map(indices, (index) => request_es("del", `/${index}`)))
+  return Promise.all(_.map(indices, (index) => request_es("del", `/${index}`)));
 }
 
 export function clear_old_indices() {
-  return get_indices().then(filter_old_indices).then(delete_indices)
+  return get_indices().then(filter_old_indices).then(delete_indices);
 }

--- a/lib/elasticsearch.ts
+++ b/lib/elasticsearch.ts
@@ -1,19 +1,25 @@
-var config  = require("../config");
+var _       = require("underscore");
+var moment  = require("moment");
 var request = require("request");
 
+var config  = require("../config");
 
-// Helper function to make ES queries. Pass it a path to query and it returns
-// a promise with the decoded result
-function get_es(path) {
-  // wrap the async request in a promise and return it
+const auth = {
+  user: config.ELASTICSEARCH_USER,
+  pass: config.ELASTICSEARCH_PASSWORD,
+  sendImmediately: false,
+};
+
+// Helper function to make ES queries. Pass it a method and a path to query and it returns
+// a promise with the decoded result.
+function request_es(method, path) {
   return new Promise((resolve, reject) => {
+    method = method.toLowerCase()
+    if (!_.contains(["put", "patch", "post", "head", "del", "get"], method)) {
+      reject(new Error(`Invalid method ${method}`))
+    }
     const url = config.ELASTICSEARCH_URL + path;
-    const auth = {
-      user: config.ELASTICSEARCH_USER,
-      pass: config.ELASTICSEARCH_PASSWORD,
-      sendImmediately: false,
-    };
-    request.get({url, auth}, (error, response, body) => {
+    request[method]({url, auth}, (error, response, body) => {
       if (error != null) {
         reject(error);
       } else if (response.statusCode === 200) {
@@ -23,6 +29,10 @@ function get_es(path) {
       }
     });
   });
+}
+
+function get_es(path) {
+  return request_es("get", path);
 }
 
 
@@ -40,4 +50,30 @@ export function get_indices() {
     });
     return filtered_indices.sort();
   });
+}
+
+// We want to keep 14 days of indices. Let's do 15 so I don't have to think hard about what happens
+// when the time is in UTC or when we're before/after midnight.
+const NUM_DAYS = 15;
+
+function filter_old_indices(current_indices) {
+  return new Promise((resolve, reject) => {
+    const acceptable_indices = [];
+    let today = moment();
+    for (let i = 0; i < NUM_DAYS; i++) {
+      acceptable_indices.push(`logs-${today.format("YYYY.MM.DD")}`);
+      today = today.subtract(1, 'days');
+    }
+    current_indices.push('fake-index');
+    const indices = _.difference(current_indices, acceptable_indices);
+    resolve(indices);
+  })
+}
+
+function delete_indices(indices) {
+  return Promise.all(_.map(indices, (index) => request_es("del", `/${index}`)))
+}
+
+export function clear_old_indices() {
+  return get_indices().then(filter_old_indices).then(delete_indices)
 }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "eslint-plugin-jsx-a11y": "^0.6.2",
     "eslint-plugin-react": "^4.3.0",
     "mocha": "^2.4.5",
+    "nock": "^8.0.0",
     "node-dev": "^3.1.0",
     "sinon": "^1.17.3",
     "tslint": "^3.7.3"

--- a/package.json
+++ b/package.json
@@ -3,9 +3,11 @@
   "version": "0.1.0",
   "dependencies": {
     "express": "^4.13.4",
+    "moment": "^2.12.0",
     "request": "^2.70.0",
     "ts-node": "^0.7.1",
-    "typescript": "^1.8.9"
+    "typescript": "^1.8.9",
+    "underscore": "^1.8.3"
   },
   "scripts": {
     "dev-server": "NODE_ENV=development node_modules/node-dev/bin/node-dev server.ts; kill %1",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,9 @@
   "name": "elasticsearch-toolbox",
   "version": "0.1.0",
   "dependencies": {
+    "cron": "^1.1.0",
     "express": "^4.13.4",
+    "js-yaml": "^3.5.5",
     "moment": "^2.12.0",
     "request": "^2.70.0",
     "ts-node": "^0.7.1",

--- a/server.ts
+++ b/server.ts
@@ -5,9 +5,7 @@ if (+major < 5) {
 }
 
 
-var _       = require("underscore");
 var express = require("express");
-var moment  = require("moment");
 
 var config  = require("./config");
 var es      = require("./lib/elasticsearch");

--- a/server.ts
+++ b/server.ts
@@ -23,6 +23,7 @@ app.get("/status/indices", (req, res) => {
   });
 });
 
+// Delete all indexes older than 14 days
 app.get("/indices/clear", (req, res) => {
   es.clear_old_indices().then((cleared_indices) => {
     console.log("cleared", cleared_indices);

--- a/server.ts
+++ b/server.ts
@@ -18,8 +18,8 @@ app.use("/static", express.static("static"));
 app.get("/status/indices", (req, res) => {
   es.get_indices().then((indices) => {
     res.status(200).send(indices);
-  }).catch((data) => {
-    res.status(500).send(data);
+  }).catch((err) => {
+    res.status(500).send(err.message);
   });
 });
 

--- a/server.ts
+++ b/server.ts
@@ -38,8 +38,8 @@ if (config.indices.clearAt) {
   var job = new cron.CronJob({
     cronTime: config.indices.clearAt,
     onTick: () => {
-      es.clear_old_indices().then(() => {
-        console.log("cleared old indices");
+      es.clear_old_indices().then((indices) => {
+        console.log("deleted indices", indices);
       }).catch((err) => {
         console.error("failure clearing old indices", err);
       });

--- a/server.ts
+++ b/server.ts
@@ -5,7 +5,10 @@ if (+major < 5) {
 }
 
 
+var _       = require("underscore");
 var express = require("express");
+var moment  = require("moment");
+
 var config  = require("./config");
 var es      = require("./lib/elasticsearch");
 
@@ -16,14 +19,18 @@ app.use("/static", express.static("static"));
 // list the index stats as a json object
 app.get("/status/indices", (req, res) => {
   es.get_indices().then((indices) => {
-    var data = JSON.stringify(indices);
-    res.set({
-      "Content-Length": data.length,
-      "Content-Type": "application/json",
-    });
-    res.status(200).send(data);
+    res.status(200).send(indices);
   }).catch((data) => {
     res.status(500).send(data);
+  });
+});
+
+app.get("/indices/clear", (req, res) => {
+  es.clear_old_indices().then((cleared_indices) => {
+    console.log("cleared", cleared_indices);
+    res.status(200).send(cleared_indices);
+  }).catch((err) => {
+    res.status(500).send(err.message);
   });
 });
 

--- a/test/elasticsearch.ts
+++ b/test/elasticsearch.ts
@@ -1,28 +1,48 @@
 var assert  = require("assert");
-var request = require("request");
-var sinon   = require("sinon");
+var moment  = require("moment");
+var nock    = require("nock");
 
 var es = require("../lib/elasticsearch");
 
 
 describe("elasticsearch", () => {
   describe("get_indices", () => {
-    before((done) => {
-      // mock the request.get call in `get_es`
-      const es_data = {indices: {index1: [], index2: [], ".kibana-4": []}};
-      sinon.stub(request, "get").yields(null, {statusCode: 200}, JSON.stringify(es_data));
-      done();
-    });
-
-    after((done) => {
-      request.get.restore();
-      done();
-    });
-
-    it("should return a list of indices", () => {
+    it("should return a list of indices", (done) => {
+      const fakeES = nock(process.env.ELASTICSEARCH_URL)
+        .get("/_stats?level=shards")
+        .reply(200, {indices: {index1: [], index2: [], ".kibana-4": []}});
       const expected = ["index1", "index2"];
       es.get_indices().then((indices) => {
         assert.deepEqual(indices, expected);
+        fakeES.done();
+        done();
+      }).catch((err) => {
+        done(err);
+      });
+    });
+  });
+
+  describe("clear_old_indices", () => {
+    it("should make delete requests for all old indices", (done) => {
+      const today = moment();
+      const yesterday = today.subtract(1, "days");
+      const lastMonth = today.subtract(1, "month");
+      const format = (m) => m.format("YYYY.MM.DD");
+
+      const expected = {indices: {}};
+      expected.indices[`logs-${format(today)}`] = [];
+      expected.indices[`logs-${format(yesterday)}`] = [];
+      expected.indices[`logs-${format(lastMonth)}`] = [];
+      const fakeES = nock(process.env.ELASTICSEARCH_URL)
+        .get("/_stats?level=shards")
+        .reply(200, expected)
+        .delete(`/logs-${format(lastMonth)}`)
+        .reply(200, {});
+      es.clear_old_indices().then(() => {
+        fakeES.done();
+        done();
+      }).catch((err) => {
+        done(err);
       });
     });
   });

--- a/test/elasticsearch.ts
+++ b/test/elasticsearch.ts
@@ -38,7 +38,8 @@ describe("elasticsearch", () => {
         .reply(200, expected)
         .delete(`/logs-${format(lastMonth)}`)
         .reply(200, {});
-      es.clear_old_indices().then(() => {
+      es.clear_old_indices().then((indices) => {
+        assert.deepEqual(indices, [`logs-${format(lastMonth)}`]);
         fakeES.done();
         done();
       }).catch((err) => {


### PR DESCRIPTION
Exposes an API endpoint that clears old indices. Also optionally allows you to clear them at an interval