### PR TITLE
support keeping aliases up to date

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -46,7 +46,7 @@ module.exports.indices = conf.indices;
 if (conf.indices.aliases) {
   module.exports.aliases = {mappings: {}};
   for (const key of Object.keys(conf.indices.aliases)) {
-    const val = conf.indices.aliases[key]
+    const val = conf.indices.aliases[key];
     if (key === "updateAt") {
       module.exports.aliases.updateAt = val;
     } else {

--- a/config.ts
+++ b/config.ts
@@ -42,3 +42,15 @@ if (!conf.indices.days) {
 }
 
 module.exports.indices = conf.indices;
+
+if (conf.indices.aliases) {
+  module.exports.aliases = {mappings: {}};
+  for (const key of Object.keys(conf.indices.aliases)) {
+    const val = conf.indices.aliases[key]
+    if (key === "updateAt") {
+      module.exports.aliases.updateAt = val;
+    } else {
+      module.exports.aliases.mappings[key] = val;
+    }
+  }
+}

--- a/config.yml
+++ b/config.yml
@@ -6,3 +6,8 @@ indices:
   # OPTIONAL: Cron timestamp (sec, min, hour, day of month, month, day of week) in UTC.
   # If specified, clears the old indices at that interval.
   clearAt: "0 0 9 * * *" # 2 am PT is 9 am UTC
+  # OPTIONAL: Mappings from alias names to number of days of indexes to keep in that alias.
+  aliases:
+    last_2days: 2
+    # OPTIONAL: Cron timestamp in UTC. If specified, the aliases will be updated at that interval.
+    updateAt: "0 0 0 * * *"

--- a/lib/elasticsearch.ts
+++ b/lib/elasticsearch.ts
@@ -10,9 +10,9 @@ const auth = {
   sendImmediately: false,
 };
 
-// Helper function to make ES queries. Pass it a method and a path to query and it returns
-// a promise with the decoded result.
-function request_es(method, path) {
+// Helper function to make ES queries. Pass it a method, a path to query, and an optional body and
+// it returns a promise with the decoded result.
+function request_es(method, path, json) {
   return new Promise((resolve, reject) => {
     // For safety, don't assume the method comes in in a consistent case.
     const meth = method.toLowerCase();
@@ -20,7 +20,19 @@ function request_es(method, path) {
       reject(new Error(`Invalid method ${meth}`));
     }
     const url = config.ELASTICSEARCH_URL + path;
-    request[meth]({url, auth}, (error, response, body) => {
+    const opts = {
+      url: url,
+      auth: auth,
+      body: undefined,
+      headers: undefined,
+    };
+    // We'd like to just use request's json option, but that assumes that the response will also be
+    // JSON, which is not the case with ES.
+    if (json != null) {
+      opts.body = JSON.stringify(json);
+      opts.headers = {"Content-type": "application/json"};
+    }
+    request[meth](opts, (error, response, body) => {
       if (error != null) {
         reject(error);
       } else if (response.statusCode === 200) {
@@ -32,8 +44,12 @@ function request_es(method, path) {
   });
 }
 
+function request_es_no_body(method, path) {
+  return request_es(method, path, undefined);
+}
+
 function get_es(path) {
-  return request_es("get", path);
+  return request_es_no_body("get", path);
 }
 
 
@@ -70,14 +86,108 @@ function filter_old_indices(current_indices) {
 // was deleted or an error
 function delete_index(index) {
   return new Promise((resolve, reject) => {
-    request_es("del", `/${index}`).then(() => resolve(index)).catch(reject);
+    request_es_no_body("del", `/${index}`).then(() => resolve(index)).catch(reject);
   });
 }
 
 function delete_indices(indices) {
-  return Promise.all(_.map(indices, (index) => delete_index(index)));
+  return Promise.all(_.map(indices, delete_index));
 }
 
 export function clear_old_indices() {
   return get_indices().then(filter_old_indices).then(delete_indices);
+}
+
+export function update_aliases() {
+  return get_aliases().then(remove_unmanaged_aliases)
+    .then(remove_old_indices_from_aliases)
+    .then(get_aliases).then(remove_unmanaged_aliases);
+}
+
+function get_aliases() {
+  return new Promise((resolve, reject) => {
+    get_es("/_aliases").then((indices) => {
+      // The aliases endpoint returns a map from index name to metadata about those indexes.
+      // e.g.
+      //   {
+      //     ".kibana-4": {
+      //       "aliases": {}
+      //     },
+      //     "logs-2016.04.02": {
+      //       "aliases": {
+      //         "last_2days": {},
+      //         "last_2weeks": {},
+      //         "last_day": {},
+      //         "last_week": {}
+      //       }
+      //     },
+      //   }
+      // It's much easier to work with a map from alias name to list of indexes in the alias.
+      const aliases = {};
+      for (let index of Object.keys(indices)) {
+        // Filter out the kibana index
+        if (index.indexOf(".kibana") !== -1) {
+          continue
+        }
+        for (let alias of Object.keys(indices[index].aliases)) {
+          if (!aliases[alias]) {
+            aliases[alias] = []
+          }
+          aliases[alias].push(index);
+          // Keep the results sorted and unique
+          aliases[alias] = _.chain(aliases[alias]).sortBy(_.identity).uniq(true).value();
+        }
+      }
+
+      resolve(aliases);
+    }).catch((err) => {
+      reject(err);
+    });
+  });
+}
+
+function remove_unmanaged_aliases(aliases) {
+  return new Promise((resolve) => {
+    for (let alias of Object.keys(aliases)) {
+      if (!config.aliases.mappings[alias]) {
+        delete aliases[alias]
+      }
+    }
+    resolve(aliases);
+  });
+}
+
+function remove_old_indices_from_aliases(aliases) {
+  return Promise.all(_.map(aliases, update_alias_state));
+}
+
+function update_alias_state(current_indices, alias) {
+  return new Promise((resolve, reject) => {
+    const acceptable_indices = [];
+    let today = moment();
+    for (let i = 0; i < config.aliases.mappings[alias]; i++) {
+      acceptable_indices.push(`${config.indices.prefix}-${today.format("YYYY.MM.DD")}`);
+      today = today.subtract(1, "days");
+    }
+    const indices_to_remove = _.difference(current_indices, acceptable_indices);
+    const indices_to_add = _.difference(acceptable_indices, current_indices);
+
+    if (!indices_to_remove.length && !indices_to_add.length) {
+      resolve();
+      return
+    }
+
+    const action_el = (action, alias, index) => {
+      const out = {};
+      out[action] = {index, alias};
+      return out;
+    }
+    const actions = _.map(indices_to_remove, _.partial(action_el, "remove", alias))
+      .concat(_.map(indices_to_add, _.partial(action_el, "add", alias)))
+    request_es("post", "/_aliases", {"actions": actions}).then(() => {
+      resolve();
+    }).catch((err) => {
+      reject(err);
+    });
+  });
 }

--- a/lib/elasticsearch.ts
+++ b/lib/elasticsearch.ts
@@ -22,20 +22,13 @@ function request_es(method, path, json) {
     const url = config.ELASTICSEARCH_URL + path;
     const opts = {
       url, auth,
-      body: undefined,
-      headers: undefined,
+      json: json || true,
     };
-    // We'd like to just use request's json option, but that assumes that the response will also be
-    // JSON, which is not the case with ES.
-    if (json != null) {
-      opts.body = JSON.stringify(json);
-      opts.headers = {"Content-type": "application/json"};
-    }
     request[meth](opts, (error, response, body) => {
       if (error != null) {
         reject(error);
       } else if (response.statusCode === 200) {
-        resolve(JSON.parse(body));
+        resolve(body);
       } else {
         reject(new Error(`Request failed with ${response.statusCode}`));
       }

--- a/lib/elasticsearch.ts
+++ b/lib/elasticsearch.ts
@@ -153,6 +153,8 @@ function update_alias_state(current_indices, alias) {
       return;
     }
 
+    // To modify an alias, send a list of "actions" that look like:
+    //    { <add or remove>: { index: <index name>, alias: <alias name> } }
     const action_el = (action, index) => {
       const out = {};
       out[action] = {index, alias};
@@ -160,11 +162,10 @@ function update_alias_state(current_indices, alias) {
     };
     const actions = _.map(indices_to_remove, _.partial(action_el, "remove"))
       .concat(_.map(indices_to_add, _.partial(action_el, "add")));
+
     request_es("post", "/_aliases", {actions}).then(() => {
       resolve();
-    }).catch((err) => {
-      reject(err);
-    });
+    }).catch(reject);
   });
 }
 

--- a/lib/elasticsearch.ts
+++ b/lib/elasticsearch.ts
@@ -126,7 +126,7 @@ function get_aliases() {
   });
 }
 
-function remove_unmanaged_aliases(aliases) {
+function filter_managed_aliases(aliases) {
   return new Promise((resolve) => {
     for (const alias of Object.keys(aliases)) {
       if (!config.aliases.mappings[alias]) {
@@ -173,7 +173,7 @@ function remove_old_indices_from_aliases(aliases) {
 }
 
 export function update_aliases() {
-  return get_aliases().then(remove_unmanaged_aliases)
+  return get_aliases().then(filter_managed_aliases)
     .then(remove_old_indices_from_aliases)
-    .then(get_aliases).then(remove_unmanaged_aliases);
+    .then(get_aliases).then(filter_managed_aliases);
 }

--- a/server.ts
+++ b/server.ts
@@ -58,6 +58,22 @@ if (config.indices.clearAt) {
   job.start();
 }
 
+if (config.aliases && config.aliases.updateAt) {
+  console.log(`updating aliases at at '${config.aliases.updateAt}'`);
+  var job = new cron.CronJob({
+    cronTime: config.aliases.updateAt,
+    onTick: () => {
+      es.update_aliases().then((aliases) => {
+        console.log("set aliases to", aliases);
+      }).catch((err) => {
+        console.error("failure updating aliases", err);
+      });
+    },
+    start: false,
+  });
+  job.start();
+}
+
 if (require.main === module) {
   app.listen(config.PORT, () => {
     console.log(`Server listening on port ${config.PORT}`);

--- a/server.ts
+++ b/server.ts
@@ -24,10 +24,19 @@ app.get("/status/indices", (req, res) => {
   });
 });
 
-// Delete all indexes older than 14 days
+// Delete all indexes older than a configured number of days
 app.get("/indices/clear", (req, res) => {
   es.clear_old_indices().then((cleared_indices) => {
     res.status(200).send(cleared_indices);
+  }).catch((err) => {
+    res.status(500).send(err.message);
+  });
+});
+
+// Update all time-based index aliases and return the new alias state
+app.get("/aliases/update", (req, res) => {
+  es.update_aliases().then((aliases) => {
+    res.status(200).send(aliases);
   }).catch((err) => {
     res.status(500).send(err.message);
   });

--- a/server.ts
+++ b/server.ts
@@ -44,7 +44,7 @@ app.get("/aliases/update", (req, res) => {
 
 if (config.indices.clearAt) {
   console.log(`clearing indexes at '${config.indices.clearAt}'`);
-  var job = new cron.CronJob({
+  const job = new cron.CronJob({
     cronTime: config.indices.clearAt,
     onTick: () => {
       es.clear_old_indices().then((indices) => {
@@ -60,7 +60,7 @@ if (config.indices.clearAt) {
 
 if (config.aliases && config.aliases.updateAt) {
   console.log(`updating aliases at at '${config.aliases.updateAt}'`);
-  var job = new cron.CronJob({
+  const job = new cron.CronJob({
     cronTime: config.aliases.updateAt,
     onTick: () => {
       es.update_aliases().then((aliases) => {

--- a/test/elasticsearch.ts
+++ b/test/elasticsearch.ts
@@ -4,6 +4,10 @@ var nock    = require("nock");
 
 var es = require("../lib/elasticsearch");
 
+const today = moment();
+const yesterday = moment().subtract(1, "days");
+const lastMonth = moment().subtract(1, "month");
+const format = (m) => m.format("YYYY.MM.DD");
 
 describe("elasticsearch", () => {
   describe("get_indices", () => {
@@ -16,19 +20,12 @@ describe("elasticsearch", () => {
         assert.deepEqual(indices, expected);
         fakeES.done();
         done();
-      }).catch((err) => {
-        done(err);
-      });
+      }).catch(done);
     });
   });
 
   describe("clear_old_indices", () => {
     it("should make delete requests for all old indices", (done) => {
-      const today = moment();
-      const yesterday = today.subtract(1, "days");
-      const lastMonth = today.subtract(1, "month");
-      const format = (m) => m.format("YYYY.MM.DD");
-
       const expected = {indices: {}};
       expected.indices[`logs-${format(today)}`] = [];
       expected.indices[`logs-${format(yesterday)}`] = [];
@@ -42,9 +39,38 @@ describe("elasticsearch", () => {
         assert.deepEqual(indices, [`logs-${format(lastMonth)}`]);
         fakeES.done();
         done();
-      }).catch((err) => {
-        done(err);
-      });
+      }).catch(done);
+    });
+  });
+
+  describe("update_aliases", () => {
+    it("should make one command to put aliases to the right state", (done) => {
+      const current = {};
+      current[`logs-${format(yesterday)}`] = {aliases: {last_2days: {}}};
+      current[`logs-${format(lastMonth)}`] = {aliases: {last_2days: {}}};
+
+      const expected = {};
+      expected[`logs-${format(yesterday)}`] = {aliases: {last_2days: {}}};
+      expected[`logs-${format(today)}`] = {aliases: {last_2days: {}}};
+
+      const fakeES = nock(process.env.ELASTICSEARCH_URL)
+        .get("/_aliases")
+        .reply(200, current)
+        .post("/_aliases",
+              {actions: [
+                {remove: {index: `logs-${format(lastMonth)}`, alias: "last_2days"}},
+                {add: {index: `logs-${format(today)}`, alias: "last_2days"}},
+              ],
+              })
+        .reply(200)
+        .get("/_aliases")
+        .reply(200, expected);
+      es.update_aliases().then((aliases) => {
+        assert.deepEqual(aliases,
+                         {last_2days: [`logs-${format(yesterday)}`, `logs-${format(today)}`]});
+        fakeES.done();
+        done();
+      }).catch(done);
     });
   });
 });


### PR DESCRIPTION
This adds an `/aliases/update` endpoint that updates all specified time-based aliases based on the config. It also adds an optional cron time to update the aliases at.