### PR TITLE
repeatedly clearing out old indices is safe so lets do it more often

### DIFF
--- a/lib/elasticsearch.ts
+++ b/lib/elasticsearch.ts
@@ -100,15 +100,21 @@ function delete_index(index) {
   return request_es_no_body("del", `/${index}`).then(() => index);
 }
 
-function delete_indices(indices) {
-  // group indices together so we can use less requests
-  // ["log1", "log2", "log3", ...] => ["log1,log2,log3", "log4,log5,log6"]
-  const grouped_indices = _.chain(indices).chunk(20).map((arr) => arr.join(",")).value();
-  return Promise.all(_.map(grouped_indices, delete_index));
+// delete_indices returns a function that will delete all the indices at the specified chunk size
+function delete_indices(chunksize) {
+  return function f(indices) {
+    // group indices together so we can use less requests
+    // ["log1", "log2", "log3", ...] => ["log1,log2,log3", "log4,log5,log6"]
+    const grouped_indices = _.chain(indices).chunk(chunksize).map((arr) => arr.join(",")).value();
+    return Promise.all(_.map(grouped_indices, delete_index));
+  };
 }
 
-export function clear_old_indices() {
-  return get_indices().then(filter_managed_indices).then(filter_old_indices).then(delete_indices);
+export function clear_old_indices(chunksize = 20) {
+  return get_indices()
+    .then(filter_managed_indices)
+    .then(filter_old_indices)
+    .then(delete_indices(chunksize));
 }
 
 function get_aliases() {

--- a/lib/elasticsearch.ts
+++ b/lib/elasticsearch.ts
@@ -101,7 +101,10 @@ function delete_index(index) {
 }
 
 function delete_indices(indices) {
-  return Promise.all(_.map(indices, delete_index));
+  // group indices together so we can use less requests
+  // ["log1", "log2", "log3", ...] => ["log1,log2,log3", "log4,log5,log6"]
+  const grouped_indices = _.chain(indices).chunk(20).map((arr) => arr.join(",")).value();
+  return Promise.all(_.map(grouped_indices, delete_index));
 }
 
 export function clear_old_indices() {

--- a/lib/elasticsearch.ts
+++ b/lib/elasticsearch.ts
@@ -1,4 +1,4 @@
-var _       = require("underscore");
+var _       = require("lodash");
 var moment  = require("moment");
 var request = require("request");
 
@@ -16,7 +16,7 @@ function request_es(method, path, json) {
   return new Promise((resolve, reject) => {
     // For safety, don't assume the method comes in in a consistent case.
     const meth = method.toLowerCase();
-    if (!_.contains(["put", "patch", "post", "head", "del", "get"], meth)) {
+    if (!_.includes(["put", "patch", "post", "head", "del", "get"], meth)) {
       reject(new Error(`Invalid method ${meth}`));
     }
     const url = config.ELASTICSEARCH_URL + path;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "request": "^2.70.0",
     "ts-node": "^0.7.1",
     "typescript": "^1.8.9",
-    "underscore": "^1.8.3"
+    "lodash": "^4.16.0"
   },
   "scripts": {
     "dev-server": "NODE_ENV=development node_modules/node-dev/bin/node-dev server.ts; kill %1",

--- a/test/elasticsearch.ts
+++ b/test/elasticsearch.ts
@@ -46,8 +46,10 @@ describe("elasticsearch", () => {
     });
 
     it("should chunk up delete requests for all old indices", (done) => {
+      const chunksize = 20;
+      const totalindices = 110;
       const returned_indices = {};
-      for (let i = 0; i < 30; i++) {
+      for (let i = 0; i < totalindices; i++) {
         const old_date = format(moment().subtract(1, "month").subtract(i, "days"));
         returned_indices[`logs-${old_date}`] = [];
       }
@@ -55,7 +57,7 @@ describe("elasticsearch", () => {
       const deleted_indices = _.chain(returned_indices)
         .keys()
         .sort()
-        .chunk(20)
+        .chunk(chunksize)
         .map((arr) => arr.join(","))
         .value();
 
@@ -68,7 +70,7 @@ describe("elasticsearch", () => {
           .reply(200, {});
       }
 
-      es.clear_old_indices().then((indices) => {
+      es.clear_old_indices(chunksize).then((indices) => {
         assert.deepEqual(indices, deleted_indices);
         fakeES.done();
         done();


### PR DESCRIPTION
https://clever.atlassian.net/browse/INFRA-2073

we have this bug where machines are actively logging with really old
timestamps. this creates new indices and takes up space on the
elasticsearch boxes. we should just clear them out more often which is
safe because by definition, we are only clearing out old indices.