### PR TITLE
only delete an index if it matches the date format

### DIFF
--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -1,0 +1,1 @@
+module.exports.date_format = "YYYY-MM-DD";

--- a/test/elasticsearch.ts
+++ b/test/elasticsearch.ts
@@ -4,11 +4,12 @@ var moment  = require("moment");
 var nock    = require("nock");
 
 var es = require("../lib/elasticsearch");
+var constants = require("../lib/constants");
 
 const today = moment();
 const yesterday = moment().subtract(1, "days");
 const lastMonth = moment().subtract(1, "month");
-const format = (m) => m.format("YYYY-MM-DD");
+const format = (m) => m.format(constants.date_format);
 
 describe("elasticsearch", () => {
   describe("get_indices", () => {
@@ -33,6 +34,7 @@ describe("elasticsearch", () => {
       returned_indices[`logs-${format(today)}`] = [];
       returned_indices[`logs-${format(yesterday)}`] = [];
       returned_indices[`logs-${format(lastMonth)}`] = [];
+      returned_indices["logs-not-a-date"] = [];
       const fakeES = nock(process.env.ELASTICSEARCH_URL)
         .get("/*/_settings")
         .reply(200, returned_indices)


### PR DESCRIPTION
This makes es-toolbox more discerning about which indexes to delete. This would have prevented the requests we had to make to AWS to restore indexes back when we switched the prod ES cluster.

I'm doing this now to prevent the same happening with the dev cluster.