### PR TITLE
keep log indices for 14 instead of 9 days

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -2,7 +2,7 @@ indices:
   # We assume that all indices are named as {prefix}-YYYY.MM.DD
   prefix: "logs"
   # How many days of indices to keep
-  days: 9
+  days: 14
   # OPTIONAL: Cron timestamp (sec, min, hour, day of month, month, day of week) in UTC.
   # If specified, clears the old indices at that interval.
   clearAt: "0 5 9 * * *" # 2:05 am PT is 9:05 am UTC


### PR DESCRIPTION
AWS Elasticsearch Service automatically stores up to 14 snapshots [doc](https://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-managedomains-snapshots.html), but we have been removing snapshots older than 9 days (in [`filter_old_indices`](https://github.com/Clever/elasticsearch-toolbox/blob/83d9fb1c55e13b3b22cc03ac0937d49771691235/lib/elasticsearch.ts#L95)).  This PR has us from keep old indices a bit longer by increasing the x-day cutoff from 9 to 14 days. 