### PR TITLE
Revert "keep log indices for 14 instead of 9 days"

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -2,7 +2,7 @@ indices:
   # We assume that all indices are named as {prefix}-YYYY.MM.DD
   prefix: "logs"
   # How many days of indices to keep
-  days: 14
+  days: 9
   # OPTIONAL: Cron timestamp (sec, min, hour, day of month, month, day of week) in UTC.
   # If specified, clears the old indices at that interval.
   clearAt: "0 5 9 * * *" # 2:05 am PT is 9:05 am UTC


### PR DESCRIPTION
No longer using this change to keep logs around. Also, it took a very intense toll on the cluster when we were. 

Reverts Clever/elasticsearch-toolbox#27