### PR TITLE
fix updating of the last_2days alias

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -10,7 +10,7 @@ indices:
   aliases:
     last_2days: 2
     # OPTIONAL: Cron timestamp in UTC. If specified, the aliases will be updated at that interval.
-    updateAt: "0 0 0 * * *"
+    updateAt: "0 10 0 * * *"
   # OPTIONAL: Change the replicas for indices older than `days` to the new quantity `value`.
   # replicas:
   #   days: 1


### PR DESCRIPTION
this has been failing for a while now, it seems https://production--haproxy-logs.int.clever.com/_plugin/kibana/app/kibana#/doc/78e8dcb0-fff4-11e8-819f-3dbcf12e7319/logs-2019-01-15/daily-logs?id=1547510400044986250&_g=()

The error is index not found, so I moved the cron back to 10 minutes after midnight UTC to give the index time to create